### PR TITLE
Rename instances of "edge engine" to "serverless scripting"

### DIFF
--- a/graphql/README.md
+++ b/graphql/README.md
@@ -42,7 +42,7 @@ To build the project, run
 yarn build
 ```
 
-The output `dist/main.js` can be run from StackPath's EdgeEngine.
+The output `dist/main.js` can be run from StackPath's serverless scripting platform.
 
 ### Curl Example
 

--- a/graphql/package.json
+++ b/graphql/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "edge-engine-graphql",
+  "name": "serverless-scripting-graphql",
   "private": true,
   "main": "index.js",
   "license": "MIT",

--- a/jwt-validation/package.json
+++ b/jwt-validation/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "edge-engine-jwt-validation",
+  "name": "serverless-scripting-jwt-validation",
   "version": "1.0.0",
   "description": "An example StackPath serverless script that will perform JWT validation of requests",
   "scripts": {


### PR DESCRIPTION
Rename the last instances of the old Edge Engine marketing term that were missed in #7.