### PR TITLE
Add a URL redirection example

### DIFF
--- a/url-redirection/README.md
+++ b/url-redirection/README.md
@@ -1,0 +1,13 @@
+# URL Redirection
+
+This script is live and in use by StackPath to redirect requests from the 
+original StackPath developer site at 
+[developer.stackpath.com](https://developer.stackpath.com/) to the newer site at 
+[stackpath.dev](https://stackpath.dev). It defines a set of original URL paths 
+and new paths to redirect to. Redirects occur as an HTTP 301 response to the 
+browser. If a redirection rule isn't defined then the script returns the result from the original request.
+
+## Installation
+
+* Re-define `redirectHost` and `redirects` in `url-redirection.js` with your site's new host and redirection rules. 
+* Upload `url-redirection.js` as a site's serverless script either via the [StackPath customer portal](https://control.stackpath.com) or [API](https://stackpath.dev/reference/serverless-scripting#createsitescript). The script should listen on the `/` path so every request to the site is intercepted by the script. 

--- a/url-redirection/url-redirection.js
+++ b/url-redirection/url-redirection.js
@@ -1,0 +1,83 @@
+addEventListener("fetch", event => {
+  event.respondWith(handleRequest(event.request));
+});
+
+/**
+ * Redirect requests from developer.stackpath.com to stackpath.dev.
+ *
+ * @param {Request} request
+ */
+async function handleRequest(request) {
+  try {
+    // The site to redirect requests to.
+    const redirectHost = 'https://stackpath.dev';
+
+    // A map of paths at the original site and new paths to redirect to.
+    const redirects = new Map([
+      // The home page
+      ['/', ''],
+      ['/en/', ''],
+
+      // The welcome section
+      ['/docs/en/getting-started/', 'docs/getting-started'],
+
+      // CDN guides
+      ['/docs/en/cdn/static-site-s3/', 'docs/static-site-with-s3'],
+      ['/docs/en/cdn/getting-stack-metrics/', 'docs/getting-stack-metrics'],
+
+      // Serverless scripting guides
+      ['/docs/en/EdgeEngine/introduction/', 'docs/introduction'],
+      ['/docs/en/EdgeEngine/edgeengine-quickstart/', 'docs/getting-started-1'],
+      ['/docs/en/EdgeEngine/available-apis/', 'docs/available-apis'],
+      ['/docs/en/EdgeEngine/debug/', 'docs/debugging'],
+      ['/docs/en/EdgeEngine/cli/', 'docs/edgeengine-cli'],
+      ['/docs/en/EdgeEngine/block-countries/', 'docs/block-countries'],
+      ['/docs/en/EdgeEngine/cookies/', 'docs/cookies'],
+      ['/docs/en/EdgeEngine/crypto/', 'docs/crypto'],
+      ['/docs/en/EdgeEngine/in-memory-caching/', 'docs/in-memory-caching'],
+      ['/docs/en/EdgeEngine/modify-headers/', 'docs/modify-headers'],
+      ['/docs/en/EdgeEngine/modify-response-body/', 'docs/modify-response-body'],
+      ['/docs/en/EdgeEngine/request-header-variables/', 'docs/request-header-variables'],
+      ['/docs/en/EdgeEngine/static-response/', 'docs/static-response'],
+
+      // Edge computing guides
+      ['/docs/en/edgecomputing/creating-a-workload/', 'docs/create-a-container-workload'],
+
+      // API references
+      ['/en/api/identity/', 'reference/accounts'],
+      ['/en/api/dns/', 'reference/scanning'],
+      ['/en/api/cdn/', 'reference/infrastructure'],
+      ['/en/api/workload/', 'reference/workloads'],
+      ['/en/api/waf/', 'reference/infrastructure-2'],
+      ['/en/api/monitoring/', 'reference/http-monitoring'],
+      ['/en/api/stacks/', 'reference/stacks'],
+    ]);
+
+    // Make sure the request path ends with a / so map gets will work for
+    // requests without a trailing slash.
+    let path = new URL(request.url).pathname;
+    if (!path.endsWith('/')) {
+      path += '/';
+    }
+
+    const redirectTo = redirects.get(path);
+
+    // If there wasn't a redirect defined then return the fetched original
+    // request.
+    //
+    // Consider logging when this happens.
+    if (redirectTo === undefined) {
+      const response = await fetch(request);
+      return response;
+    }
+
+    // Otherwise, redirect the user to the new URL.
+    const response = new Response();
+    response.status = 301;
+    response.statusText = 'Moved Permanently';
+    response.headers.set('Location', `${redirectHost}/${redirectTo}`);
+    return response;
+  } catch (e) {
+    return new Response(e.stack || e, { status: 500 });
+  }
+}

--- a/url-redirection/url-redirection.js
+++ b/url-redirection/url-redirection.js
@@ -1,3 +1,47 @@
+// The site to redirect requests to.
+const redirectHost = 'https://stackpath.dev';
+
+// A map of paths at the original site and new paths to redirect to.
+const redirects = new Map([
+  // The home page
+  ['/', ''],
+  ['/en/', ''],
+
+  // The welcome section
+  ['/docs/en/getting-started/', 'docs/getting-started'],
+
+  // CDN guides
+  ['/docs/en/cdn/static-site-s3/', 'docs/static-site-with-s3'],
+  ['/docs/en/cdn/getting-stack-metrics/', 'docs/getting-stack-metrics'],
+
+  // Serverless scripting guides
+  ['/docs/en/EdgeEngine/introduction/', 'docs/introduction'],
+  ['/docs/en/EdgeEngine/edgeengine-quickstart/', 'docs/getting-started-1'],
+  ['/docs/en/EdgeEngine/available-apis/', 'docs/available-apis'],
+  ['/docs/en/EdgeEngine/debug/', 'docs/debugging'],
+  ['/docs/en/EdgeEngine/cli/', 'docs/edgeengine-cli'],
+  ['/docs/en/EdgeEngine/block-countries/', 'docs/block-countries'],
+  ['/docs/en/EdgeEngine/cookies/', 'docs/cookies'],
+  ['/docs/en/EdgeEngine/crypto/', 'docs/crypto'],
+  ['/docs/en/EdgeEngine/in-memory-caching/', 'docs/in-memory-caching'],
+  ['/docs/en/EdgeEngine/modify-headers/', 'docs/modify-headers'],
+  ['/docs/en/EdgeEngine/modify-response-body/', 'docs/modify-response-body'],
+  ['/docs/en/EdgeEngine/request-header-variables/', 'docs/request-header-variables'],
+  ['/docs/en/EdgeEngine/static-response/', 'docs/static-response'],
+
+  // Edge computing guides
+  ['/docs/en/edgecomputing/creating-a-workload/', 'docs/create-a-container-workload'],
+
+  // API references
+  ['/en/api/identity/', 'reference/accounts'],
+  ['/en/api/dns/', 'reference/scanning'],
+  ['/en/api/cdn/', 'reference/infrastructure'],
+  ['/en/api/workload/', 'reference/workloads'],
+  ['/en/api/waf/', 'reference/infrastructure-2'],
+  ['/en/api/monitoring/', 'reference/http-monitoring'],
+  ['/en/api/stacks/', 'reference/stacks'],
+]);
+
 addEventListener('fetch', event => {
   event.respondWith(handleRequest(event.request));
 });
@@ -9,50 +53,6 @@ addEventListener('fetch', event => {
  */
 async function handleRequest(request) {
   try {
-    // The site to redirect requests to.
-    const redirectHost = 'https://stackpath.dev';
-
-    // A map of paths at the original site and new paths to redirect to.
-    const redirects = new Map([
-      // The home page
-      ['/', ''],
-      ['/en/', ''],
-
-      // The welcome section
-      ['/docs/en/getting-started/', 'docs/getting-started'],
-
-      // CDN guides
-      ['/docs/en/cdn/static-site-s3/', 'docs/static-site-with-s3'],
-      ['/docs/en/cdn/getting-stack-metrics/', 'docs/getting-stack-metrics'],
-
-      // Serverless scripting guides
-      ['/docs/en/EdgeEngine/introduction/', 'docs/introduction'],
-      ['/docs/en/EdgeEngine/edgeengine-quickstart/', 'docs/getting-started-1'],
-      ['/docs/en/EdgeEngine/available-apis/', 'docs/available-apis'],
-      ['/docs/en/EdgeEngine/debug/', 'docs/debugging'],
-      ['/docs/en/EdgeEngine/cli/', 'docs/edgeengine-cli'],
-      ['/docs/en/EdgeEngine/block-countries/', 'docs/block-countries'],
-      ['/docs/en/EdgeEngine/cookies/', 'docs/cookies'],
-      ['/docs/en/EdgeEngine/crypto/', 'docs/crypto'],
-      ['/docs/en/EdgeEngine/in-memory-caching/', 'docs/in-memory-caching'],
-      ['/docs/en/EdgeEngine/modify-headers/', 'docs/modify-headers'],
-      ['/docs/en/EdgeEngine/modify-response-body/', 'docs/modify-response-body'],
-      ['/docs/en/EdgeEngine/request-header-variables/', 'docs/request-header-variables'],
-      ['/docs/en/EdgeEngine/static-response/', 'docs/static-response'],
-
-      // Edge computing guides
-      ['/docs/en/edgecomputing/creating-a-workload/', 'docs/create-a-container-workload'],
-
-      // API references
-      ['/en/api/identity/', 'reference/accounts'],
-      ['/en/api/dns/', 'reference/scanning'],
-      ['/en/api/cdn/', 'reference/infrastructure'],
-      ['/en/api/workload/', 'reference/workloads'],
-      ['/en/api/waf/', 'reference/infrastructure-2'],
-      ['/en/api/monitoring/', 'reference/http-monitoring'],
-      ['/en/api/stacks/', 'reference/stacks'],
-    ]);
-
     // Make sure the request path ends with a / so map gets will work for
     // requests without a trailing slash.
     let path = new URL(request.url).pathname;

--- a/url-redirection/url-redirection.js
+++ b/url-redirection/url-redirection.js
@@ -1,4 +1,4 @@
-addEventListener("fetch", event => {
+addEventListener('fetch', event => {
   event.respondWith(handleRequest(event.request));
 });
 

--- a/url-redirection/url-redirection.js
+++ b/url-redirection/url-redirection.js
@@ -72,11 +72,13 @@ async function handleRequest(request) {
     }
 
     // Otherwise, redirect the user to the new URL.
-    const response = new Response();
-    response.status = 301;
-    response.statusText = 'Moved Permanently';
-    response.headers.set('Location', `${redirectHost}/${redirectTo}`);
-    return response;
+    return new Response(null, {
+      status: 301,
+      statusText: "Moved Permanently",
+      headers: {
+        Location: `${redirectHost}/${redirectTo}`
+      }
+    });
   } catch (e) {
     return new Response(e.stack || e, { status: 500 });
   }


### PR DESCRIPTION
I'm going to write a StackPath blog post about how we used a serverless script to redirect requests from our old developer site to the new one and felt it'd be nice to show this off as an example. This script is in use and verified working in production.